### PR TITLE
feat: add PC shooter bootstrap (yellow MK powerups)

### DIFF
--- a/Assets/Scripts/Bootstrapper.cs
+++ b/Assets/Scripts/Bootstrapper.cs
@@ -1,0 +1,277 @@
+using TopDownShooter.Core;
+using TopDownShooter.Entities;
+using TopDownShooter.UI;
+using TopDownShooter.Systems;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TopDownShooter
+{
+    public class Bootstrapper : MonoBehaviour
+    {
+        // Optional: drag a ScriptableObject GameConfig; if null, a default is created at runtime
+        public GameConfig Config;
+
+        private ObjectPool<Bullet> _bulletPool;
+        private HUDController _hud;
+
+        private void Start()
+        {
+            Application.targetFrameRate = 60;
+
+            // Camera
+            var camGO = new GameObject("MainCamera");
+            var cam = camGO.AddComponent<Camera>();
+            cam.orthographic = true;
+            cam.orthographicSize = 8f;
+            cam.clearFlags = CameraClearFlags.SolidColor;
+            cam.backgroundColor = new Color(0.06f, 0.07f, 0.1f);
+            camGO.tag = "MainCamera";
+
+            // Arena
+            CreateArenaLines();
+
+            // Player
+            var player = CreatePlayer();
+
+            // Bullets + pool
+            var bulletPrefab = CreateBulletPrefab();
+            _bulletPool = new ObjectPool<Bullet>(bulletPrefab, 64, this.transform);
+            player.Init(ConfigOrDefault(), _bulletPool);
+
+            // Spawner
+            var spawnerGO = new GameObject("Spawner");
+            var spawner = spawnerGO.AddComponent<Spawner>();
+            spawner.Config = ConfigOrDefault();
+            spawner.Player = player.transform;
+            spawner.EnemyPrefab = CreateEnemyPrefab();
+            spawner.PowerUpPrefab = CreatePowerUpPrefab();
+
+            // HUD
+            _hud = CreateHUD();
+            _hud.Bind(player);
+        }
+
+        private GameConfig ConfigOrDefault()
+        {
+            if (Config != null) return Config;
+            var cfg = ScriptableObject.CreateInstance<GameConfig>();
+            return cfg;
+        }
+
+        private PlayerController CreatePlayer()
+        {
+            var go = new GameObject("Player");
+            go.transform.position = Vector3.zero;
+
+            var sr = go.AddComponent<SpriteRenderer>();
+            sr.sprite = MakeCircleSprite(new Color(1f, 0.92f, 0.35f), 64); // yellow-ish ship
+            sr.sortingOrder = 10;
+
+            var pc = go.AddComponent<PlayerController>();
+            go.AddComponent<Rigidbody2D>();
+            go.AddComponent<CapsuleCollider2D>();
+
+            return pc;
+        }
+
+        private GameObject CreateEnemyPrefab()
+        {
+            var go = new GameObject("EnemyPrefab");
+            var sr = go.AddComponent<SpriteRenderer>();
+            sr.sprite = MakeTriangleSprite(new Color(0.95f, 0.45f, 0.35f), 64); // reddish enemy
+            sr.sortingOrder = 5;
+
+            go.AddComponent<Rigidbody2D>();
+            go.AddComponent<CircleCollider2D>();
+            go.AddComponent<EnemyController>();
+
+            go.SetActive(false);
+            go.transform.SetParent(this.transform);
+            return go;
+        }
+
+        private GameObject CreatePowerUpPrefab()
+        {
+            var go = new GameObject("PowerUpPrefab");
+            var sr = go.AddComponent<SpriteRenderer>();
+            sr.sprite = MakeDiamondSprite(new Color(1f, 0.95f, 0.4f), 64); // yellow MK orb
+            sr.sortingOrder = 6;
+
+            go.AddComponent<CircleCollider2D>();
+            go.AddComponent<PowerUp>();
+
+            go.SetActive(false);
+            go.transform.SetParent(this.transform);
+            return go;
+        }
+
+        private Bullet CreateBulletPrefab()
+        {
+            var go = new GameObject("BulletPrefab");
+            var sr = go.AddComponent<SpriteRenderer>();
+            sr.sprite = MakeCircleSprite(new Color(1f, 1f, 0.8f), 32);
+            sr.sortingOrder = 8;
+
+            var b = go.AddComponent<Bullet>();
+            go.AddComponent<Rigidbody2D>();
+            go.AddComponent<CircleCollider2D>();
+
+            go.SetActive(false);
+            go.transform.SetParent(this.transform);
+            return b;
+        }
+
+        private HUDController CreateHUD()
+        {
+            var canvasGO = new GameObject("HUD");
+            var canvas = canvasGO.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+            canvasGO.AddComponent<CanvasScaler>().uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            canvasGO.AddComponent<GraphicRaycaster>();
+
+            var mk = CreateText(canvasGO.transform, new Vector2(12, -12), "MK 1", 20);
+            var score = CreateText(canvasGO.transform, new Vector2(12, -36), "0", 20);
+
+            var hpGO = new GameObject("HPBar");
+            hpGO.transform.SetParent(canvasGO.transform, false);
+            var rect = hpGO.AddComponent<RectTransform>();
+            rect.anchorMin = new Vector2(1, 1);
+            rect.anchorMax = new Vector2(1, 1);
+            rect.pivot = new Vector2(1, 1);
+            rect.anchoredPosition = new Vector2(-12, -12);
+            rect.sizeDelta = new Vector2(200, 18);
+
+            var bg = new GameObject("BG");
+            bg.transform.SetParent(hpGO.transform, false);
+            var bgImg = bg.AddComponent<Image>();
+            var bgRect = bg.GetComponent<RectTransform>();
+            bgRect.anchorMin = new Vector2(0, 0);
+            bgRect.anchorMax = new Vector2(1, 1);
+            bgRect.offsetMin = Vector2.zero;
+            bgRect.offsetMax = Vector2.zero;
+            bgImg.color = new Color(0, 0, 0, 0.4f);
+
+            var slider = hpGO.AddComponent<Slider>();
+            slider.transition = Selectable.Transition.None;
+            var fillArea = new GameObject("FillArea");
+            fillArea.transform.SetParent(hpGO.transform, false);
+            var faRect = fillArea.AddComponent<RectTransform>();
+            faRect.anchorMin = new Vector2(0, 0);
+            faRect.anchorMax = new Vector2(1, 1);
+            faRect.offsetMin = new Vector2(2, 2);
+            faRect.offsetMax = new Vector2(-2, -2);
+
+            var fill = new GameObject("Fill");
+            fill.transform.SetParent(faRect, false);
+            var fillImg = fill.AddComponent<Image>();
+            fillImg.color = new Color(1f, 0.85f, 0.25f);
+            var fillRect = fill.GetComponent<RectTransform>();
+            fillRect.anchorMin = new Vector2(0, 0);
+            fillRect.anchorMax = new Vector2(1, 1);
+            fillRect.offsetMin = Vector2.zero;
+            fillRect.offsetMax = Vector2.zero;
+
+            slider.fillRect = fillRect;
+            slider.targetGraphic = fillImg;
+            slider.direction = Slider.Direction.LeftToRight;
+
+            var hud = canvasGO.AddComponent<HUDController>();
+            hud.HpBar = slider;
+            hud.ScoreText = score.GetComponent<UnityEngine.UI.Text>();
+            hud.MKText = mk.GetComponent<UnityEngine.UI.Text>();
+            return hud;
+        }
+
+        private GameObject CreateText(Transform parent, Vector2 anchored, string content, int size)
+        {
+            var go = new GameObject("Text");
+            go.transform.SetParent(parent, false);
+            var rect = go.AddComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0, 1);
+            rect.anchorMax = new Vector2(0, 1);
+            rect.pivot = new Vector2(0, 1);
+            rect.anchoredPosition = anchored;
+            var text = go.AddComponent<UnityEngine.UI.Text>();
+            text.text = content;
+            text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            text.fontSize = size;
+            text.color = new Color(1f, 0.95f, 0.6f);
+            text.alignment = TextAnchor.UpperLeft;
+            return go;
+        }
+
+        private void CreateArenaLines()
+        {
+            var cfg = ConfigOrDefault();
+            float w = cfg.arenaSize.x;
+            float h = cfg.arenaSize.y;
+
+            CreateLine(new Vector2(-w/2, -h/2), new Vector2(w/2, -h/2));
+            CreateLine(new Vector2(-w/2,  h/2), new Vector2(w/2,  h/2));
+            CreateLine(new Vector2(-w/2, -h/2), new Vector2(-w/2,  h/2));
+            CreateLine(new Vector2( w/2, -h/2), new Vector2( w/2,  h/2));
+        }
+
+        private void CreateLine(Vector2 a, Vector2 b)
+        {
+            var go = new GameObject("Line");
+            var lr = go.AddComponent<LineRenderer>();
+            lr.positionCount = 2;
+            lr.SetPosition(0, a);
+            lr.SetPosition(1, b);
+            lr.startWidth = lr.endWidth = 0.05f;
+            lr.material = new Material(Shader.Find("Sprites/Default"));
+            lr.startColor = lr.endColor = new Color(0.3f, 0.32f, 0.4f);
+            lr.sortingOrder = 1;
+        }
+
+        // --- quick sprite makers (procedural placeholders) ---
+        private Sprite MakeCircleSprite(Color color, int size)
+        {
+            var tex = new Texture2D(size, size, TextureFormat.RGBA32, false);
+            var r = size * 0.5f;
+            for (int y = 0; y < size; y++)
+            for (int x = 0; x < size; x++)
+            {
+                var dx = x - r + 0.5f;
+                var dy = y - r + 0.5f;
+                var inside = (dx*dx + dy*dy) <= (r*r);
+                tex.SetPixel(x, y, inside ? color : Color.clear);
+            }
+            tex.Apply();
+            return Sprite.Create(tex, new Rect(0,0,size,size), new Vector2(0.5f, 0.5f), 32f);
+        }
+
+        private Sprite MakeTriangleSprite(Color color, int size)
+        {
+            var tex = new Texture2D(size, size, TextureFormat.RGBA32, false);
+            for (int y = 0; y < size; y++)
+            for (int x = 0; x < size; x++)
+            {
+                float fx = (x / (float)(size-1)) * 2f - 1f;
+                float fy = (y / (float)(size-1)) * 2f - 1f;
+                bool inside = fy >= -0.8f && fy <= 0.8f && Mathf.Abs(fx) <= (fy + 1f);
+                tex.SetPixel(x, y, inside ? color : Color.clear);
+            }
+            tex.Apply();
+            return Sprite.Create(tex, new Rect(0,0,size,size), new Vector2(0.5f, 0.5f), 32f);
+        }
+
+        private Sprite MakeDiamondSprite(Color color, int size)
+        {
+            var tex = new Texture2D(size, size, TextureFormat.RGBA32, false);
+            float r = size * 0.5f;
+            for (int y = 0; y < size; y++)
+            for (int x = 0; x < size; x++)
+            {
+                float dx = Mathf.Abs(x - r + 0.5f);
+                float dy = Mathf.Abs(y - r + 0.5f);
+                bool inside = dx + dy <= r * 0.9f;
+                tex.SetPixel(x, y, inside ? color : Color.clear);
+            }
+            tex.Apply();
+            return Sprite.Create(tex, new Rect(0,0,size,size), new Vector2(0.5f, 0.5f), 32f);
+        }
+    }
+}

--- a/Assets/Scripts/Core/GameConfig.cs
+++ b/Assets/Scripts/Core/GameConfig.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+namespace TopDownShooter.Core
+{
+    [CreateAssetMenu(menuName = "TopDownShooter/GameConfig")]
+    public class GameConfig : ScriptableObject
+    {
+        [Header("Player")]
+        public float playerSpeed = 7f;
+        public float bulletSpeed = 18f;
+        public float fireCooldown = 0.12f;
+        public int   playerMaxHP = 5;
+
+        [Header("Enemies")]
+        public float enemySpeed = 3.5f;
+        public float enemySpawnInterval = 1.2f;
+        public int   enemyHP = 2;
+
+        [Header("Waves")]
+        public int maxEnemiesOnField = 20;
+
+        [Header("Drops")]
+        public float powerupDropChance = 0.15f;
+
+        [Header("Gameplay")]
+        public Vector2 arenaSize = new Vector2(24f, 14f); // world units (width x height)
+    }
+}

--- a/Assets/Scripts/Core/ObjectPool.cs
+++ b/Assets/Scripts/Core/ObjectPool.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TopDownShooter.Core
+{
+    public class ObjectPool<T> where T : Component
+    {
+        private readonly Stack<T> _stack = new();
+        private readonly T _prefab;
+        private readonly Transform _parent;
+
+        public ObjectPool(T prefab, int preload, Transform parent = null)
+        {
+            _prefab = prefab;
+            _parent = parent;
+            for (int i = 0; i < preload; i++)
+            {
+                var inst = GameObject.Instantiate(_prefab, _parent);
+                inst.gameObject.SetActive(false);
+                _stack.Push(inst);
+            }
+        }
+
+        public T Get()
+        {
+            if (_stack.Count > 0)
+            {
+                var obj = _stack.Pop();
+                obj.gameObject.SetActive(true);
+                return obj;
+            }
+            return GameObject.Instantiate(_prefab, _parent);
+        }
+
+        public void Release(T obj)
+        {
+            obj.gameObject.SetActive(false);
+            _stack.Push(obj);
+        }
+    }
+}

--- a/Assets/Scripts/Entities/Bullet.cs
+++ b/Assets/Scripts/Entities/Bullet.cs
@@ -1,0 +1,52 @@
+using TopDownShooter.Core;
+using UnityEngine;
+
+namespace TopDownShooter.Entities
+{
+    [RequireComponent(typeof(Rigidbody2D), typeof(CircleCollider2D), typeof(SpriteRenderer))]
+    public class Bullet : MonoBehaviour
+    {
+        public float Speed;
+        public float Lifetime = 2.5f;
+        public int Damage = 1;
+
+        private float _timer;
+        private Rigidbody2D _rb;
+        private ObjectPool<Bullet> _pool;
+
+        public void Init(ObjectPool<Bullet> pool) => _pool = pool;
+
+        private void Awake()
+        {
+            _rb = GetComponent<Rigidbody2D>();
+            _rb.gravityScale = 0f;
+            _rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
+            var col = GetComponent<CircleCollider2D>();
+            col.isTrigger = true;
+            col.radius = 0.12f;
+        }
+
+        public void Fire(Vector2 position, Vector2 dir, float speed)
+        {
+            transform.position = position;
+            _rb.velocity = dir.normalized * speed;
+            _timer = 0f;
+        }
+
+        private void Update()
+        {
+            _timer += Time.deltaTime;
+            if (_timer >= Lifetime)
+                _pool.Release(this);
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (other.TryGetComponent<EnemyController>(out var enemy))
+            {
+                enemy.TakeDamage(Damage);
+                _pool.Release(this);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Entities/EnemyController.cs
+++ b/Assets/Scripts/Entities/EnemyController.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+
+namespace TopDownShooter.Entities
+{
+    [RequireComponent(typeof(Rigidbody2D), typeof(CircleCollider2D), typeof(SpriteRenderer))]
+    public class EnemyController : MonoBehaviour
+    {
+        public int MaxHP = 2;
+        public float Speed = 3f;
+
+        private int _hp;
+        private Rigidbody2D _rb;
+        private Transform _target;
+        private TopDownShooter.Spawner _spawner;
+
+        private void Awake()
+        {
+            _rb = GetComponent<Rigidbody2D>();
+            _rb.gravityScale = 0f;
+            _rb.drag = 0f;
+            var col = GetComponent<CircleCollider2D>();
+            col.isTrigger = true;
+            col.radius = 0.35f;
+        }
+
+        public void Init(Transform target, TopDownShooter.Spawner spawner, int hp, float speed)
+        {
+            _target = target;
+            _spawner = spawner;
+            _hp = hp;
+            Speed = speed;
+        }
+
+        private void Update()
+        {
+            if (_target == null) return;
+            var dir = (_target.position - transform.position).normalized;
+            _rb.velocity = dir * Speed;
+            var angle = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg;
+            transform.rotation = Quaternion.Euler(0, 0, angle - 90f);
+        }
+
+        public void TakeDamage(int dmg)
+        {
+            _hp -= dmg;
+            if (_hp <= 0)
+            {
+                _spawner.OnEnemyKilled(this, transform.position);
+                Destroy(gameObject);
+            }
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (other.TryGetComponent<PlayerController>(out var player))
+            {
+                player.TakeDamage(1);
+                _spawner.OnEnemyKilled(this, transform.position);
+                Destroy(gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Entities/PlayerController.cs
+++ b/Assets/Scripts/Entities/PlayerController.cs
@@ -1,0 +1,119 @@
+using TopDownShooter.Core;
+using UnityEngine;
+
+namespace TopDownShooter.Entities
+{
+    [RequireComponent(typeof(Rigidbody2D), typeof(CapsuleCollider2D), typeof(SpriteRenderer))]
+    public class PlayerController : MonoBehaviour
+    {
+        public int MaxHP = 5;
+        public float MoveSpeed = 7f;
+        public float FireCooldown = 0.12f;
+        public float BulletSpeed = 18f;
+
+        public int HP { get; private set; }
+        public int MKLevel { get; private set; } = 1;
+
+        private Rigidbody2D _rb;
+        private Camera _cam;
+        private float _fireTimer;
+        private ObjectPool<Bullet> _bulletPool;
+
+        public System.Action<int, int> OnHPChanged; // (hp,max)
+        public System.Action<int> OnMKChanged;      // level
+
+        private void Awake()
+        {
+            _rb = GetComponent<Rigidbody2D>();
+            _rb.gravityScale = 0f;
+            _cam = Camera.main;
+            var col = GetComponent<CapsuleCollider2D>();
+            col.isTrigger = true;
+            col.direction = CapsuleDirection2D.Vertical;
+            col.size = new Vector2(0.6f, 1.1f);
+        }
+
+        public void Init(GameConfig cfg, ObjectPool<Bullet> bulletPool)
+        {
+            MaxHP = cfg.playerMaxHP;
+            MoveSpeed = cfg.playerSpeed;
+            FireCooldown = cfg.fireCooldown;
+            BulletSpeed = cfg.bulletSpeed;
+
+            HP = MaxHP;
+            OnHPChanged?.Invoke(HP, MaxHP);
+            _bulletPool = bulletPool;
+        }
+
+        private void Update()
+        {
+            // Movement
+            var x = (Input.GetKey(KeyCode.D) || Input.GetKey(KeyCode.RightArrow) ? 1 : 0)
+                  - (Input.GetKey(KeyCode.A) || Input.GetKey(KeyCode.LeftArrow)  ? 1 : 0);
+            var y = (Input.GetKey(KeyCode.W) || Input.GetKey(KeyCode.UpArrow)    ? 1 : 0)
+                  - (Input.GetKey(KeyCode.S) || Input.GetKey(KeyCode.DownArrow)  ? 1 : 0);
+            var v = new Vector2(x, y);
+            if (v.sqrMagnitude > 1f) v.Normalize();
+            _rb.velocity = v * MoveSpeed;
+
+            // Aim to mouse
+            var mouseWorld = _cam.ScreenToWorldPoint(Input.mousePosition);
+            var dir = (mouseWorld - transform.position);
+            dir.z = 0;
+            if (dir.sqrMagnitude > 0.001f)
+            {
+                var angle = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg;
+                transform.rotation = Quaternion.Euler(0, 0, angle - 90f);
+            }
+
+            // Shooting
+            _fireTimer -= Time.deltaTime;
+            if (Input.GetMouseButton(0) && _fireTimer <= 0f)
+            {
+                Shoot(dir.normalized);
+                _fireTimer = FireCooldown;
+            }
+        }
+
+        private void Shoot(Vector2 dir)
+        {
+            // MK levels fire patterns
+            if (MKLevel <= 1) FireOne(dir, 0f);
+            else if (MKLevel == 2) { FireOne(dir, -6f); FireOne(dir, 6f); }
+            else { FireOne(dir, -10f); FireOne(dir, 0f); FireOne(dir, 10f); }
+        }
+
+        private void FireOne(Vector2 dir, float spreadDeg)
+        {
+            var rad = spreadDeg * Mathf.Deg2Rad;
+            var spreadDir = new Vector2(
+                dir.x * Mathf.Cos(rad) - dir.y * Mathf.Sin(rad),
+                dir.x * Mathf.Sin(rad) + dir.y * Mathf.Cos(rad)
+            );
+
+            var bullet = _bulletPool.Get();
+            bullet.Init(_bulletPool);
+            bullet.transform.position = transform.position + (Vector3)(spreadDir * 0.8f);
+            bullet.GetComponent<SpriteRenderer>().color = new Color(1f, 0.95f, 0.3f, 1f);
+            bullet.Fire(bullet.transform.position, spreadDir, BulletSpeed);
+        }
+
+        public void TakeDamage(int dmg)
+        {
+            HP = Mathf.Max(0, HP - dmg);
+            OnHPChanged?.Invoke(HP, MaxHP);
+        }
+
+        public void Heal(int amount)
+        {
+            HP = Mathf.Min(MaxHP, HP + amount);
+            OnHPChanged?.Invoke(HP, MaxHP);
+        }
+
+        public void UpgradeMK()
+        {
+            MKLevel = Mathf.Clamp(MKLevel + 1, 1, 3);
+            OnMKChanged?.Invoke(MKLevel);
+        }
+    }
+}

--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -1,0 +1,59 @@
+using TopDownShooter.Core;
+using TopDownShooter.Entities;
+using UnityEngine;
+using Random = UnityEngine.Random;
+
+namespace TopDownShooter
+{
+    public class Spawner : MonoBehaviour
+    {
+        public GameConfig Config;
+        public Transform Player;
+        public GameObject EnemyPrefab;
+        public GameObject PowerUpPrefab;
+
+        private float _timer;
+
+        private void Update()
+        {
+            if (Player == null || EnemyPrefab == null) return;
+
+            _timer += Time.deltaTime;
+            if (_timer >= Config.enemySpawnInterval)
+            {
+                _timer = 0f;
+                var existing = FindObjectsOfType<EnemyController>().Length;
+                if (existing < Config.maxEnemiesOnField)
+                    SpawnEnemy();
+            }
+        }
+
+        private void SpawnEnemy()
+        {
+            var halfW = Config.arenaSize.x * 0.5f;
+            var halfH = Config.arenaSize.y * 0.5f;
+
+            // random edge spawn
+            var edge = Random.Range(0, 4);
+            Vector2 pos = edge switch
+            {
+                0 => new Vector2(-halfW, Random.Range(-halfH, halfH)),
+                1 => new Vector2(halfW, Random.Range(-halfH, halfH)),
+                2 => new Vector2(Random.Range(-halfW, halfW), halfH),
+                _ => new Vector2(Random.Range(-halfW, halfW), -halfH),
+            };
+
+            var enemy = Instantiate(EnemyPrefab, pos, Quaternion.identity);
+            var ec = enemy.GetComponent<EnemyController>();
+            ec.Init(Player, this, Config.enemyHP, Config.enemySpeed);
+        }
+
+        public void OnEnemyKilled(EnemyController enemy, Vector3 where)
+        {
+            if (Random.value < Config.powerupDropChance)
+            {
+                Instantiate(PowerUpPrefab, where, Quaternion.identity);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/PowerUp.cs
+++ b/Assets/Scripts/Systems/PowerUp.cs
@@ -1,0 +1,25 @@
+using TopDownShooter.Entities;
+using UnityEngine;
+
+namespace TopDownShooter.Systems
+{
+    [RequireComponent(typeof(CircleCollider2D), typeof(SpriteRenderer))]
+    public class PowerUp : MonoBehaviour
+    {
+        private void Awake()
+        {
+            var col = GetComponent<CircleCollider2D>();
+            col.isTrigger = true;
+            col.radius = 0.35f;
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (other.TryGetComponent<PlayerController>(out var player))
+            {
+                player.UpgradeMK();
+                Destroy(gameObject);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/HUDController.cs
+++ b/Assets/Scripts/UI/HUDController.cs
@@ -1,0 +1,37 @@
+using TopDownShooter.Entities;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TopDownShooter.UI
+{
+    public class HUDController : MonoBehaviour
+    {
+        public Slider HpBar;
+        public Text   ScoreText;
+        public Text   MKText;
+
+        private int _score;
+
+        public void Bind(PlayerController player)
+        {
+            player.OnHPChanged += (hp, max) =>
+            {
+                if (HpBar != null)
+                {
+                    HpBar.maxValue = max;
+                    HpBar.value = hp;
+                }
+            };
+            player.OnMKChanged += (mk) =>
+            {
+                if (MKText != null) MKText.text = $"MK {mk}";
+            };
+        }
+
+        public void AddScore(int v = 1)
+        {
+            _score += v;
+            if (ScoreText != null) ScoreText.text = _score.ToString("N0");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable GameConfig ScriptableObject for arena, player and enemies
- implement object pooling with Bullet, Enemy and MK power-up entities
- bootstrap spawner, HUD and runtime-generated sprites for a minimal top-down shooter

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689730064298832bbbb0ef49680d77ab