### PR TITLE
fix: make camera visible and ensure enemies are active

### DIFF
--- a/Assets/Scripts/Bootstrapper.cs
+++ b/Assets/Scripts/Bootstrapper.cs
@@ -19,14 +19,19 @@ namespace TopDownShooter
         {
             Application.targetFrameRate = 60;
 
-            // Camera
-            var camGO = new GameObject("MainCamera");
-            var cam = camGO.AddComponent<Camera>();
+            // Camera (reuse if exists)
+            Camera cam = Camera.main;
+            if (cam == null)
+            {
+                var camGO = new GameObject("MainCamera");
+                cam = camGO.AddComponent<Camera>();
+                camGO.tag = "MainCamera";
+            }
             cam.orthographic = true;
             cam.orthographicSize = 8f;
             cam.clearFlags = CameraClearFlags.SolidColor;
             cam.backgroundColor = new Color(0.06f, 0.07f, 0.1f);
-            camGO.tag = "MainCamera";
+            cam.transform.position = new Vector3(0f, 0f, -10f);
 
             // Arena
             CreateArenaLines();

--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -44,6 +44,7 @@ namespace TopDownShooter
             };
 
             var enemy = Instantiate(EnemyPrefab, pos, Quaternion.identity);
+            enemy.SetActive(true);
             var ec = enemy.GetComponent<EnemyController>();
             ec.Init(Player, this, Config.enemyHP, Config.enemySpeed);
         }


### PR DESCRIPTION
## Summary
- reuse or create main camera and position it at z -10 for proper 2D rendering
- ensure enemies spawned from inactive templates are activated

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6897357f5484832bb2608bbe9ae243ab