### PR TITLE
feat: score + lives HUD and game state

### DIFF
--- a/Assets/Scripts/Bootstrapper.cs
+++ b/Assets/Scripts/Bootstrapper.cs
@@ -55,6 +55,10 @@ namespace TopDownShooter
             // HUD
             _hud = CreateHUD();
             _hud.Bind(player);
+
+            var gmGO = new GameObject("GameManager");
+            var gm = gmGO.AddComponent<TopDownShooter.Core.GameManager>();
+            gm.Bind(_hud, player);
         }
 
         private GameConfig ConfigOrDefault()
@@ -137,6 +141,7 @@ namespace TopDownShooter
 
             var mk = CreateText(canvasGO.transform, new Vector2(12, -12), "MK 1", 20);
             var score = CreateText(canvasGO.transform, new Vector2(12, -36), "0", 20);
+            var lives = CreateText(canvasGO.transform, new Vector2(12, -60), "❤ 3", 20);
 
             var hpGO = new GameObject("HPBar");
             hpGO.transform.SetParent(canvasGO.transform, false);
@@ -182,9 +187,25 @@ namespace TopDownShooter
             slider.direction = Slider.Direction.LeftToRight;
 
             var hud = canvasGO.AddComponent<HUDController>();
+            var go = new GameObject("GameOver");
+            go.transform.SetParent(canvasGO.transform, false);
+            var gorect = go.AddComponent<RectTransform>();
+            gorect.anchorMin = new Vector2(0,0); gorect.anchorMax = new Vector2(1,1);
+            gorect.offsetMin = gorect.offsetMax = Vector2.zero;
+            var goimg = go.AddComponent<Image>(); goimg.color = new Color(0,0,0,0.6f);
+            var gotxt = CreateText(go.transform, new Vector2(0, -20), "GAME OVER", 48);
+            gotxt.GetComponent<UnityEngine.UI.Text>().alignment = TextAnchor.MiddleCenter;
+            var trect = gotxt.GetComponent<RectTransform>();
+            trect.anchorMin = trect.anchorMax = new Vector2(0.5f, 0.5f);
+            trect.pivot = new Vector2(0.5f, 0.5f);
+            trect.anchoredPosition = Vector2.zero;
+            go.SetActive(false);
+
             hud.HpBar = slider;
             hud.ScoreText = score.GetComponent<UnityEngine.UI.Text>();
             hud.MKText = mk.GetComponent<UnityEngine.UI.Text>();
+            hud.LivesText = lives.GetComponent<UnityEngine.UI.Text>();
+            hud.GameOverPanel = go;
             return hud;
         }
 

--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -1,0 +1,45 @@
+using TopDownShooter.Entities;
+using TopDownShooter.UI;
+using UnityEngine;
+
+namespace TopDownShooter.Core
+{
+    public class GameManager : MonoBehaviour
+    {
+        public int Lives = 3;
+        public int Score = 0;
+
+        HUDController _hud;
+        PlayerController _player;
+
+        public void Bind(HUDController hud, PlayerController player)
+        {
+            _hud = hud; _player = player;
+            _hud.SetLives(Lives);
+            _hud.SetScore(Score);
+            player.OnHPChanged += (hp, max) => { if (hp <= 0) OnPlayerDown(); };
+        }
+
+        public void AddScore(int v = 1)
+        {
+            Score += v;
+            _hud?.SetScore(Score);
+        }
+
+        void OnPlayerDown()
+        {
+            Lives = Mathf.Max(0, Lives - 1);
+            _hud?.SetLives(Lives);
+            if (Lives <= 0)
+            {
+                Time.timeScale = 0f;
+                _hud?.ShowGameOver(Score);
+            }
+            else
+            {
+                // simple respawn: heal and continue
+                _player.Heal(_player.MaxHP);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Spawner.cs
+++ b/Assets/Scripts/Spawner.cs
@@ -51,6 +51,7 @@ namespace TopDownShooter
 
         public void OnEnemyKilled(EnemyController enemy, Vector3 where)
         {
+            FindObjectOfType<TopDownShooter.Core.GameManager>()?.AddScore(100);
             if (Random.value < Config.powerupDropChance)
             {
                 Instantiate(PowerUpPrefab, where, Quaternion.identity);

--- a/Assets/Scripts/UI/HUDController.cs
+++ b/Assets/Scripts/UI/HUDController.cs
@@ -9,8 +9,8 @@ namespace TopDownShooter.UI
         public Slider HpBar;
         public Text   ScoreText;
         public Text   MKText;
-
-        private int _score;
+        public Text   LivesText;
+        public GameObject GameOverPanel;
 
         public void Bind(PlayerController player)
         {
@@ -22,16 +22,16 @@ namespace TopDownShooter.UI
                     HpBar.value = hp;
                 }
             };
-            player.OnMKChanged += (mk) =>
-            {
-                if (MKText != null) MKText.text = $"MK {mk}";
-            };
+            player.OnMKChanged += (mk) => { if (MKText != null) MKText.text = $"MK {mk}"; };
         }
 
-        public void AddScore(int v = 1)
+        public void SetScore(int s) { if (ScoreText) ScoreText.text = s.ToString("N0"); }
+        public void SetLives(int l) { if (LivesText) LivesText.text = $"❤ {l}"; }
+
+        public void ShowGameOver(int score)
         {
-            _score += v;
-            if (ScoreText != null) ScoreText.text = _score.ToString("N0");
+            if (GameOverPanel != null) GameOverPanel.SetActive(true);
+            if (ScoreText) ScoreText.text = $"Score: {score:N0}";
         }
     }
 }


### PR DESCRIPTION
## Summary
- add GameManager to manage score, lives, and game over logic
- extend HUD to show lives, score, and game over panel
- bootstrap GameManager and HUD elements and award score for kills

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689738d7ba30832b9781ca25b6c3bbbe