### PR TITLE
fix: disable parallax & arena lines, black background

### DIFF
--- a/Assets/Scripts/Bootstrapper.cs
+++ b/Assets/Scripts/Bootstrapper.cs
@@ -11,6 +11,8 @@ namespace TopDownShooter
     {
         // Optional: drag a ScriptableObject GameConfig; if null, a default is created at runtime
         public GameConfig Config;
+        public bool SpawnParallax = false;
+        public bool DrawArenaLines = false;
 
         private ObjectPool<Bullet> _bulletPool;
         private HUDController _hud;
@@ -33,14 +35,17 @@ namespace TopDownShooter
             camCtrl.OrthoSize = 12f;
 
             // Arena
-            CreateArenaLines();
+            if (DrawArenaLines) CreateArenaLines();
 
             // Player
             var player = CreatePlayer();
             camCtrl.Target = player.transform;
-            var bg = new GameObject("ParallaxBackground");
-            var par = bg.AddComponent<TopDownShooter.Rendering.ParallaxBackground>();
-            par.Follow = player.transform;
+            if (SpawnParallax)
+            {
+                var bg = new GameObject("ParallaxBackground");
+                var par = bg.AddComponent<TopDownShooter.Rendering.ParallaxBackground>();
+                par.Follow = player.transform;
+            }
 
             // Bullets + pool
             var bulletPrefab = CreateBulletPrefab();

--- a/Assets/Scripts/Rendering/CameraController.cs
+++ b/Assets/Scripts/Rendering/CameraController.cs
@@ -18,7 +18,7 @@ namespace TopDownShooter.Rendering
                 _cam.orthographic = true;
                 _cam.orthographicSize = OrthoSize;
                 _cam.clearFlags = CameraClearFlags.SolidColor;
-                _cam.backgroundColor = new Color(0.06f, 0.07f, 0.1f);
+                _cam.backgroundColor = Color.black;
             }
         }
 


### PR DESCRIPTION
## Summary
- set camera background to pure black
- add options to disable parallax and arena lines by default

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68973d3c520c832ba37484dee31bfad1