### PR TITLE
fix: proper camera zoom + muzzle bullets + remove duplicate components + Unity6 font

### DIFF
--- a/Assets/Scripts/Bootstrapper.cs
+++ b/Assets/Scripts/Bootstrapper.cs
@@ -37,7 +37,8 @@ namespace TopDownShooter
             cam.transform.position = new Vector3(0f, 0f, -10f);
             var camCtrl = cam.gameObject.GetComponent<TopDownShooter.Rendering.CameraController>();
             if (camCtrl == null) camCtrl = cam.gameObject.AddComponent<TopDownShooter.Rendering.CameraController>();
-            camCtrl.OrthoSize = 36f;
+            camCtrl.OrthoSize = 36f;   // wide
+            cam.orthographicSize = camCtrl.OrthoSize;
 
             // Arena
             if (DrawArenaLines) CreateArenaLines();
@@ -93,9 +94,7 @@ namespace TopDownShooter
             else sr.sprite = MakeCircleSprite(new Color(1f, 0.92f, 0.35f), 64);
             sr.sortingOrder = 10;
 
-            var pc = go.AddComponent<PlayerController>();
-            go.AddComponent<Rigidbody2D>();
-            go.AddComponent<CapsuleCollider2D>();
+            var pc = go.AddComponent<PlayerController>(); // Rigidbody2D & CapsuleCollider2D are required by the script
 
             return pc;
         }
@@ -109,9 +108,7 @@ namespace TopDownShooter
             else sr.sprite = MakeTriangleSprite(new Color(0.95f, 0.45f, 0.35f), 64);
             sr.sortingOrder = 5;
 
-            go.AddComponent<Rigidbody2D>();
-            go.AddComponent<CircleCollider2D>();
-            go.AddComponent<EnemyController>();
+            go.AddComponent<EnemyController>(); // RequireComponent on EnemyController will ensure needed components
 
             go.SetActive(false);
             go.transform.SetParent(this.transform);
@@ -142,9 +139,7 @@ namespace TopDownShooter
             else sr.sprite = MakeCircleSprite(new Color(1f, 1f, 0.8f), 32);
             sr.sortingOrder = 8;
 
-            var b = go.AddComponent<Bullet>();
-            go.AddComponent<Rigidbody2D>();
-            go.AddComponent<CircleCollider2D>();
+            var b = go.AddComponent<Bullet>(); // RequireComponent on Bullet will add needed components
 
             go.SetActive(false);
             go.transform.SetParent(this.transform);
@@ -240,7 +235,7 @@ namespace TopDownShooter
             rect.anchoredPosition = anchored;
             var text = go.AddComponent<UnityEngine.UI.Text>();
             text.text = content;
-            text.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            text.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
             text.fontSize = size;
             text.color = new Color(1f, 0.95f, 0.6f);
             text.alignment = TextAnchor.UpperLeft;

--- a/Assets/Scripts/Entities/PlayerController.cs
+++ b/Assets/Scripts/Entities/PlayerController.cs
@@ -11,7 +11,7 @@ namespace TopDownShooter.Entities
         public float FireCooldown = 0.12f;
         public float BulletSpeed = 18f;
         public float MuzzleOffset = 1.0f;    // distance from ship center to nose (world units)
-        public float LateralSpacing = 0.25f; // sideways offset for spread patterns
+        public float LateralSpacing = 0.25f; // sideways offset for spread
 
         public int HP { get; private set; }
         public int MKLevel { get; private set; } = 1;
@@ -33,6 +33,10 @@ namespace TopDownShooter.Entities
             col.isTrigger = true;
             col.direction = CapsuleDirection2D.Vertical;
             col.size = new Vector2(0.6f, 1.1f);
+
+            // MuzzleOffset/LateralSpacing defaults that work for most ships
+            if (MuzzleOffset <= 0f) MuzzleOffset = 1.0f;
+            if (LateralSpacing <= 0f) LateralSpacing = 0.25f;
         }
 
         public void Init(GameConfig cfg, ObjectPool<Bullet> bulletPool)
@@ -110,6 +114,7 @@ namespace TopDownShooter.Entities
 #endif
         }
 
+        
         private void Shoot(Vector2 dir)
         {
             var fwd = dir.normalized;
@@ -130,20 +135,21 @@ namespace TopDownShooter.Entities
             }
         }
 
+        
         private void FireOne(Vector2 fwd, float spreadDeg)
         {
-            // Perpendicular unit vector (right-hand)
+            // right vector perpendicular to forward
             var right = new Vector2(-fwd.y, fwd.x);
 
             float rad = spreadDeg * Mathf.Deg2Rad;
 
-            // Rotate forward by spread angle
+            // rotate forward by spread
             var dir = new Vector2(
                 fwd.x * Mathf.Cos(rad) - fwd.y * Mathf.Sin(rad),
                 fwd.x * Mathf.Sin(rad) + fwd.y * Mathf.Cos(rad)
             ).normalized;
 
-            // Start from the NOSE, with a tiny lateral offset for spread
+            // spawn at the NOSE, plus a small lateral offset for side shots
             float lateral = Mathf.Sin(rad) * LateralSpacing;
             Vector3 spawnPos = transform.position + (Vector3)(fwd * MuzzleOffset + right * lateral);
 

--- a/Assets/Scripts/Rendering/CameraController.cs
+++ b/Assets/Scripts/Rendering/CameraController.cs
@@ -2,32 +2,30 @@ using UnityEngine;
 
 namespace TopDownShooter.Rendering
 {
+    [RequireComponent(typeof(Camera))]
     public class CameraController : MonoBehaviour
     {
         public Transform Target;
         public float FollowLerp = 12f;
-        public float OrthoSize = 12f;
-
+        public float OrthoSize = 36f; // default wider
         Camera _cam;
 
         void Awake()
         {
             _cam = GetComponent<Camera>();
-            if (_cam != null)
-            {
-                _cam.orthographic = true;
-                _cam.orthographicSize = OrthoSize;
-                _cam.clearFlags = CameraClearFlags.SolidColor;
-                _cam.backgroundColor = Color.black;
-            }
+            _cam.orthographic = true;
+            _cam.clearFlags = CameraClearFlags.SolidColor;
+            _cam.backgroundColor = Color.black;
         }
 
         void LateUpdate()
         {
+            // keep size in sync with the public field
+            if (_cam != null) _cam.orthographicSize = OrthoSize;
+
             if (Target == null) return;
             var p = transform.position;
-            var t = Target.position;
-            t.z = p.z;
+            var t = Target.position; t.z = p.z;
             transform.position = Vector3.Lerp(p, t, 1f - Mathf.Exp(-FollowLerp * Time.deltaTime));
         }
     }


### PR DESCRIPTION
## Summary
- ensure camera orthographic size syncs with field
- remove duplicate component creation and use modern Unity font
- adjust bullet spawn to ship nose with muzzle offset defaults

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689745f90128832bbc4934b72e14d1d3